### PR TITLE
Update ida2pwntools.py

### DIFF
--- a/ida2pwntools.py
+++ b/ida2pwntools.py
@@ -134,6 +134,9 @@ class timer_debug_noui_t(object):
 		ida_dbg.get_processes(pis)
 
 		for proc in pis:
+			if proc.pid==0   and "attach" in proc.name:
+				target_pid=0
+				break
 			proc_name = proc.name.split(" ")[1]
 			idx = proc_name.rfind("/")
 


### PR DESCRIPTION
Add remote GDB debugger support. We can only use GDB debugger to debug aarch64 program, so this way can let this plugin support run gdb debugger quickly.